### PR TITLE
Application prevents blurry photos from being saved

### DIFF
--- a/Azul/Azul/CameraViewController.swift
+++ b/Azul/Azul/CameraViewController.swift
@@ -251,7 +251,7 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
     private var inProgressPhotoCaptureDelegates = [Int64: PhotoCaptureProcessor]()
     
     private var spinner: UIActivityIndicatorView!
-
+    
     @IBAction func capturePhoto(_ sender: UIButton) {
         let videoPreviewLayerOrientation = previewView.videoPreviewLayer.connection?.videoOrientation
         
@@ -259,12 +259,27 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
             if let photoOutputConnection = self.photoOutput.connection(with: .video) {
                 photoOutputConnection.videoOrientation = videoPreviewLayerOrientation!
             }
-            var photoSettings = AVCapturePhotoSettings()
+            
+            let pixelFormat: FourCharCode = {
+                if self.photoOutput.availablePhotoPixelFormatTypes
+                    .contains(kCVPixelFormatType_420YpCbCr8BiPlanarFullRange) {
+                    return kCVPixelFormatType_420YpCbCr8BiPlanarFullRange
+                } else if self.photoOutput.availablePhotoPixelFormatTypes
+                    .contains(kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange) {
+                    return kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange
+                } else {
+                    fatalError("No available YpCbCr formats.")
+                }
+            }()
+            
+            let photoSettings = AVCapturePhotoSettings(
+                rawPixelFormatType: 0,
+                processedFormat: [kCVPixelBufferPixelFormatTypeKey as String: pixelFormat])
             
             // Capture HEIF photos when supported. Enable auto-flash and high-resolution photos.
-            if  self.photoOutput.availablePhotoCodecTypes.contains(.hevc) {
-                photoSettings = AVCapturePhotoSettings(format: [AVVideoCodecKey: AVVideoCodecType.hevc])
-            }
+//            if  self.photoOutput.availablePhotoCodecTypes.contains(.hevc) {
+//                photoSettings = AVCapturePhotoSettings(format: [AVVideoCodecKey: AVVideoCodecType.hevc])
+//            }
             
             if self.videoDeviceInput.device.isFlashAvailable {
                 photoSettings.flashMode = .auto

--- a/Azul/Azul/PhotoCaptureDelegate.swift
+++ b/Azul/Azul/PhotoCaptureDelegate.swift
@@ -7,8 +7,15 @@ The app's photo capture delegate object.
 
 import AVFoundation
 import Photos
+import Accelerate
 
 class PhotoCaptureProcessor: NSObject {
+    let laplacian: [Float] = [-1, -1, -1,
+                              -1,  8, -1,
+                              -1, -1, -1]
+    
+    var blurryPhoto: Bool = false;
+    
     private(set) var requestedPhotoSettings: AVCapturePhotoSettings
     
     private let willCapturePhotoAnimation: () -> Void
@@ -131,6 +138,99 @@ extension PhotoCaptureProcessor: AVCapturePhotoCaptureDelegate {
         semanticSegmentationMatteDataArray.append(imageData)
     }
     
+    func getLaplacianStDev(data: UnsafeMutableRawPointer,
+                           rowBytes: Int,
+                           width: Int, height: Int,
+                           sequenceCount: Int,
+                           expectedCount: Int,
+                           orientation: UInt32? ) -> Float {
+        var sourceBuffer = vImage_Buffer(data: data,
+                                         height: vImagePixelCount(height),
+                                         width: vImagePixelCount(width),
+                                         rowBytes: rowBytes)
+        
+        var floatPixels: [Float]
+        let count = width * height
+        
+        if sourceBuffer.rowBytes == width * MemoryLayout<Pixel_8>.stride {
+            let start = sourceBuffer.data.assumingMemoryBound(to: Pixel_8.self)
+            floatPixels = vDSP.integerToFloatingPoint(
+                UnsafeMutableBufferPointer(start: start,
+                                           count: count),
+                floatingPointType: Float.self)
+        } else {
+            floatPixels = [Float](unsafeUninitializedCapacity: count) {
+                buffer, initializedCount in
+                
+                var floatBuffer = vImage_Buffer(data: buffer.baseAddress,
+                                                height: sourceBuffer.height,
+                                                width: sourceBuffer.width,
+                                                rowBytes: width * MemoryLayout<Float>.size)
+                
+                vImageConvert_Planar8toPlanarF(&sourceBuffer,
+                                               &floatBuffer,
+                                               0, 255,
+                                               vImage_Flags(kvImageNoFlags))
+                
+                initializedCount = count
+            }
+        }
+        
+        // Convolve with Laplacian.
+        vDSP.convolve(floatPixels,
+                      rowCount: height,
+                      columnCount: width,
+                      with3x3Kernel: laplacian,
+                      result: &floatPixels)
+        
+        // Calculate standard deviation.
+        var mean = Float.nan
+        var stdDev = Float.nan
+        
+        vDSP_normalize(floatPixels, 1,
+                       nil, 1,
+                       &mean, &stdDev,
+                       vDSP_Length(count))
+        return stdDev
+    }
+    
+    func photoIsBlurry(photo: AVCapturePhoto) -> Bool {
+        // Copy the pixel buffer to use it for our blur detection.
+        guard let pixelBuffer = photo.pixelBuffer else {
+            fatalError("Error acquiring pixel buffer.")
+        }
+        
+        CVPixelBufferLockBaseAddress(pixelBuffer,
+                                     CVPixelBufferLockFlags.readOnly)
+        
+        let width = CVPixelBufferGetWidthOfPlane(pixelBuffer, 0)
+        let height = CVPixelBufferGetHeightOfPlane(pixelBuffer, 0)
+        let count = width * height
+        
+        let lumaBaseAddress = CVPixelBufferGetBaseAddressOfPlane(pixelBuffer, 0)
+        let lumaRowBytes = CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer, 0)
+        
+        let lumaCopy = UnsafeMutableRawPointer.allocate(byteCount: count,
+                                                        alignment: MemoryLayout<Pixel_8>.alignment)
+        lumaCopy.copyMemory(from: lumaBaseAddress!,
+                            byteCount: count)
+        
+        
+        CVPixelBufferUnlockBaseAddress(pixelBuffer,
+                                       CVPixelBufferLockFlags.readOnly)
+        
+        let stDev = self.getLaplacianStDev(data: lumaCopy,
+                                  rowBytes: lumaRowBytes,
+                                  width: width,
+                                  height: height,
+                                  sequenceCount: photo.sequenceCount,
+                                  expectedCount: photo.resolvedSettings.expectedPhotoCount,
+                                  orientation: photo.metadata[ String(kCGImagePropertyOrientation) ] as? UInt32)
+        lumaCopy.deallocate()
+        
+        return stDev < 20;
+    }
+    
     /// - Tag: DidFinishProcessingPhoto
     func photoOutput(_ output: AVCapturePhotoOutput, didFinishProcessingPhoto photo: AVCapturePhoto, error: Error?) {
         photoProcessingHandler(false)
@@ -140,6 +240,11 @@ extension PhotoCaptureProcessor: AVCapturePhotoCaptureDelegate {
         } else {
             photoData = photo.fileDataRepresentation()
         }
+        
+        if photoIsBlurry(photo: photo) {
+            self.blurryPhoto = true
+        }
+        
         // A portrait effects matte gets generated only if AVFoundation detects a face.
         if var portraitEffectsMatte = photo.portraitEffectsMatte {
             if let orientation = photo.metadata[ String(kCGImagePropertyOrientation) ] as? UInt32 {
@@ -193,47 +298,54 @@ extension PhotoCaptureProcessor: AVCapturePhotoCaptureDelegate {
             return
         }
         
-        PHPhotoLibrary.requestAuthorization { status in
-            if status == .authorized {
-                PHPhotoLibrary.shared().performChanges({
-                    let options = PHAssetResourceCreationOptions()
-                    let creationRequest = PHAssetCreationRequest.forAsset()
-                    options.uniformTypeIdentifier = self.requestedPhotoSettings.processedFileType.map { $0.rawValue }
-                    creationRequest.addResource(with: .photo, data: photoData, options: options)
-                    
-                    if let livePhotoCompanionMovieURL = self.livePhotoCompanionMovieURL {
-                        let livePhotoCompanionMovieFileOptions = PHAssetResourceCreationOptions()
-                        livePhotoCompanionMovieFileOptions.shouldMoveFile = true
-                        creationRequest.addResource(with: .pairedVideo,
-                                                    fileURL: livePhotoCompanionMovieURL,
-                                                    options: livePhotoCompanionMovieFileOptions)
-                    }
-                    
-                    // Save Portrait Effects Matte to Photos Library only if it was generated
-                    if let portraitEffectsMatteData = self.portraitEffectsMatteData {
+        if blurryPhoto {
+            print("Photo is blurry. Photo was not saved. Please try again.")
+            blurryPhoto = false
+            self.didFinish()
+            return
+        } else {
+            PHPhotoLibrary.requestAuthorization { status in
+                if status == .authorized {
+                    PHPhotoLibrary.shared().performChanges({
+                        let options = PHAssetResourceCreationOptions()
                         let creationRequest = PHAssetCreationRequest.forAsset()
-                        creationRequest.addResource(with: .photo,
-                                                    data: portraitEffectsMatteData,
-                                                    options: nil)
+                        options.uniformTypeIdentifier = self.requestedPhotoSettings.processedFileType.map { $0.rawValue }
+                        creationRequest.addResource(with: .photo, data: photoData, options: options)
+                        
+                        if let livePhotoCompanionMovieURL = self.livePhotoCompanionMovieURL {
+                            let livePhotoCompanionMovieFileOptions = PHAssetResourceCreationOptions()
+                            livePhotoCompanionMovieFileOptions.shouldMoveFile = true
+                            creationRequest.addResource(with: .pairedVideo,
+                                                        fileURL: livePhotoCompanionMovieURL,
+                                                        options: livePhotoCompanionMovieFileOptions)
+                        }
+                        
+                        // Save Portrait Effects Matte to Photos Library only if it was generated
+                        if let portraitEffectsMatteData = self.portraitEffectsMatteData {
+                            let creationRequest = PHAssetCreationRequest.forAsset()
+                            creationRequest.addResource(with: .photo,
+                                                        data: portraitEffectsMatteData,
+                                                        options: nil)
+                        }
+                        // Save Portrait Effects Matte to Photos Library only if it was generated
+                        for semanticSegmentationMatteData in self.semanticSegmentationMatteDataArray {
+                            let creationRequest = PHAssetCreationRequest.forAsset()
+                            creationRequest.addResource(with: .photo,
+                                                        data: semanticSegmentationMatteData,
+                                                        options: nil)
+                        }
+                        
+                    }, completionHandler: { _, error in
+                        if let error = error {
+                            print("Error occurred while saving photo to photo library: \(error)")
+                        }
+                        
+                        self.didFinish()
                     }
-                    // Save Portrait Effects Matte to Photos Library only if it was generated
-                    for semanticSegmentationMatteData in self.semanticSegmentationMatteDataArray {
-                        let creationRequest = PHAssetCreationRequest.forAsset()
-                        creationRequest.addResource(with: .photo,
-                                                    data: semanticSegmentationMatteData,
-                                                    options: nil)
-                    }
-                    
-                }, completionHandler: { _, error in
-                    if let error = error {
-                        print("Error occurred while saving photo to photo library: \(error)")
-                    }
-                    
+                    )
+                } else {
                     self.didFinish()
                 }
-                )
-            } else {
-                self.didFinish()
             }
         }
     }


### PR DESCRIPTION
Based on Laplacian kernel variance (state-of-the art) for sharp images according to Apple documentation:
https://developer.apple.com/documentation/accelerate/finding_the_sharpest_image_in_a_sequence_of_captured_images

### What does this PR do?

* Prevents application from saving captured photos that are blurry

#### Merge Checklist:

- [x] The branch is up-to-date (i.e. rebased) with the base branch
- [x] Are the tests passing?
- [ ] Is GPA high enough?