### PR TITLE
Alerta Validar Foto

### DIFF
--- a/Azul/Azul.xcodeproj/project.pbxproj
+++ b/Azul/Azul.xcodeproj/project.pbxproj
@@ -307,14 +307,15 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"Azul/Preview Content\"";
-				DEVELOPMENT_TEAM = PLABBBAC7J;
+				DEVELOPMENT_TEAM = QC5FCLKM86;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = Azul/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = lewiszul;
+				PRODUCT_BUNDLE_IDENTIFIER = jv1;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 2;
@@ -328,14 +329,15 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"Azul/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = QC5FCLKM86;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = Azul/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = germanvp9;
+				PRODUCT_BUNDLE_IDENTIFIER = jv1;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 2;

--- a/Azul/Azul/EditorViewController.swift
+++ b/Azul/Azul/EditorViewController.swift
@@ -49,7 +49,7 @@ class EditorViewController: UIViewController {
         
         currentImage.image = UIImage(data: self.imageData!)
         if maskImage != nil {
-            var mask = CALayer()
+            let mask = CALayer()
             mask.contents = maskImage.cgImage
             mask.contentsGravity = .resizeAspect
             mask.frame = CGRect(x: 0, y: 0, width: self.view.frame.width, height: self.view.frame.height)
@@ -167,24 +167,45 @@ class EditorViewController: UIViewController {
     
     // Funcion que guarda la imagen en la libreria del dispositivo.
     @IBAction func saveImageToCameraRoll(_ sender: Any) {
-        let data = currentImage.image?.pngData()!
         
-        PHPhotoLibrary.requestAuthorization { status in
-            if status == .authorized {
-                PHPhotoLibrary.shared().performChanges({
-                    let options = PHAssetResourceCreationOptions()
-                    let creationRequest = PHAssetCreationRequest.forAsset()
-                    creationRequest.addResource(with: .photo, data: data!, options: options)
-                    
-                    // No se puede llamar nuevos ViewController desde otra thread que
-                    // no sea main. Por eso esta cosa.
-                    DispatchQueue.main.async {
-                        self.successfullySavedPhoto()
-                    }
-                })
+        let alerta = UIAlertController(title: "¿Deseas guardar esta foto?", message: "Asegurate de que el defecto se vea claramente y que lo hayas marcado", preferredStyle: .alert)
+        
+        let guardarFoto = UIAlertAction(title: "Guardar", style: .default, handler: { (action) -> Void in
+            print("Guardar button tapped")
+            
+            let data = self.currentImage.image?.pngData()!
+            
+            PHPhotoLibrary.requestAuthorization { status in
+                if status == .authorized {
+                    PHPhotoLibrary.shared().performChanges({
+                        let options = PHAssetResourceCreationOptions()
+                        let creationRequest = PHAssetCreationRequest.forAsset()
+                        creationRequest.addResource(with: .photo, data: data!, options: options)
+                        
+                        // No se puede llamar nuevos ViewController desde otra thread que
+                        // no sea main. Por eso esta cosa.
+                        DispatchQueue.main.async {
+                            self.successfullySavedPhoto()
+                        }
+                    })
+                }
             }
-        }
+            
+        })
+        
+        let cancelar = UIAlertAction(title: "Cancelar y Tomar foto nuevamente", style: .cancel, handler: { (action) -> Void in
+            print("Cancel button tapped")
+            self.cancel((Any).self)
+        })
+        
+        alerta.addAction(cancelar)
+        alerta.addAction(guardarFoto)
+        
+        self.present(alerta, animated: true, completion: nil)
+        
     }
+    
+    
     // Restart Button - Regresa la imagen a su estado natural.
     @IBAction func restoreImage(_ sender: Any) {
         currentImage.image = previewImage;


### PR DESCRIPTION
Se implementó la alerta que pregunta al usuario si desea guardar la fotografía en el iPad. Le describe al usuario que se asegure de que la foto está bien tomada y ha marcado el defecto claramente.
En la alerta aparecen dos opciones:
1. Guardar, que guarda la foto en el carrete.
2. Cancelar y Tomar foto nuevamente, que cancela la acción de guardar y cancela la fotografía ya tomada y regresa a la pantalla para tomar la foto.

### What does this PR do?

*

#### Merge Checklist:

- [ ] The branch is up-to-date (i.e. rebased) with the base branch
- [ ] Are the tests passing?
- [ ] Is GPA high enough?